### PR TITLE
Cybrilla wesbite link to POA header logo

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -70,6 +70,7 @@ const config: Config = {
       logo: {
         alt: "Cybrilla logo",
         src: "img/cybrilla-logo.svg",
+        href: "https://cybrilla.com/",
       },
       items: [
         {


### PR DESCRIPTION
Added a link to the Cybrilla logo in the POA header, redirecting it to https://cybrilla.com/