### PR TITLE
Update logo to link to cybrilla.com on homepage, internal link elsewhere

### DIFF
--- a/src/pages/styles.css
+++ b/src/pages/styles.css
@@ -444,6 +444,9 @@ h2 {
 .pagination-nav {
   padding-bottom: 40px;
 }
+.navbar__brand .navbar__logo {
+  max-width: 100px;
+}
 @media (min-width: 576px) {
   .container {
     max-width: 540px;
@@ -462,8 +465,8 @@ h2 {
   .card-container.card-container-gap-sm {
     flex-direction: row;
   }
-  .navbar__brand .navbar__logo img {
-    max-width: 200px;
+  .navbar__brand .navbar__logo {
+    max-width: 180px;
   }
   .footer__bottom {
     flex-direction: row;

--- a/src/theme/Navbar/Logo/index.tsx
+++ b/src/theme/Navbar/Logo/index.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { useLocation } from "@docusaurus/router";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
+export default function NavbarLogo(): JSX.Element {
+  const location = useLocation();
+  const isHomePage = location.pathname === "/";
+  const logoSrc = useBaseUrl("img/cybrilla-logo.svg"); // update if your logo path is different
+  const logoAlt = "Cybrilla logo";
+
+  return (
+    <a
+      className="navbar__brand"
+      href={isHomePage ? "https://cybrilla.com/" : "/"}
+      target={isHomePage ? "_blank" : "_self"}
+      rel="noopener noreferrer"
+    >
+      <img className="navbar__logo" src={logoSrc} alt={logoAlt} />
+    </a>
+  );
+}


### PR DESCRIPTION
Changed the Navbar logo so that,

- On the homepage, it links to [cybrilla.com](https://cybrilla.com/) in a new tab.
- On other pages, it links back to the docs homepage (/).
- Used Docusaurus swizzle to customize just the Navbar/Logo component.